### PR TITLE
Synchronize NCO's changes in prod on WCOSS2

### DIFF
--- a/ecf/def/gefs_prod00.def
+++ b/ecf/def/gefs_prod00.def
@@ -1097,7 +1097,7 @@ suite prod
           endfamily
           family cleanup
             task jgefs_atmos_post_cleanup
-             trigger ../post_processing/d0_16/atmos/jgefs_atmos_ensstat eq complete and ../post_processing/d0_16/atmos/jgefs_atmos_enspost eq complete and ../gempak/atmos/jgefs_atmos_gempak_meta eq complete and /prod/primary/18/gefs/v12.2/members/d16_35 == complete and /prod/primary/18/gefs/v12.2/post_processing/d16_35 == complete
+             trigger ../init eq complete and ../chem eq complete and ../members eq complete and ../post_processing eq complete and ../gempak eq complete and /prod/primary/18/gefs/v12.2/members/d16_35 == complete and /prod/primary/18/gefs/v12.2/post_processing/d16_35 == complete
           endfamily
         endfamily # v12.2
       endfamily # gefs

--- a/ecf/def/gefs_prod06.def
+++ b/ecf/def/gefs_prod06.def
@@ -974,7 +974,7 @@ suite prod
                 trigger c00 == complete and p01 == complete and p02 == complete and p03 == complete and p04 == complete and p05 == complete and p06 == complete and p07 == complete and p08 == complete and p09 == complete and p10 == complete and p11 == complete and p12 == complete and p13 == complete and p14 == complete and p15 == complete and p16 == complete and p17 == complete and p18 == complete and p19 == complete and p20 == complete and p21 == complete and p22 == complete and p23 == complete and p24 == complete and p25 == complete and p26 == complete and p27 == complete and p28 == complete and p29 == complete and p30 == complete
             endfamily
             family d16_35
-              edit ECF_FILES '%PACKAGEHOME%/ecf/d0_16'
+              edit ECF_FILES '%PACKAGEHOME%/ecf/d16_35'
               family p09
                 edit MEMBER 'p09'
                 family atmos
@@ -1097,7 +1097,7 @@ suite prod
           endfamily
           family cleanup
             task jgefs_atmos_post_cleanup
-              trigger ../post_processing/d0_16/atmos/jgefs_atmos_ensstat eq complete and ../post_processing/d0_16/atmos/jgefs_atmos_enspost eq complete and ../gempak/atmos/jgefs_atmos_gempak_meta eq complete
+              trigger ../init eq complete and ../chem eq complete and ../members eq complete and ../post_processing eq complete and ../gempak eq complete
           endfamily
         endfamily # v12.2
       endfamily # gefs

--- a/ecf/def/gefs_prod12.def
+++ b/ecf/def/gefs_prod12.def
@@ -974,7 +974,7 @@ suite prod
                 trigger c00 == complete and p01 == complete and p02 == complete and p03 == complete and p04 == complete and p05 == complete and p06 == complete and p07 == complete and p08 == complete and p09 == complete and p10 == complete and p11 == complete and p12 == complete and p13 == complete and p14 == complete and p15 == complete and p16 == complete and p17 == complete and p18 == complete and p19 == complete and p20 == complete and p21 == complete and p22 == complete and p23 == complete and p24 == complete and p25 == complete and p26 == complete and p27 == complete and p28 == complete and p29 == complete and p30 == complete
             endfamily
             family d16_35
-              edit ECF_FILES '%PACKAGEHOME%/ecf/d0_16'
+              edit ECF_FILES '%PACKAGEHOME%/ecf/d16_35'
               family p17
                 edit MEMBER 'p17'
                 family atmos
@@ -1097,7 +1097,7 @@ suite prod
           endfamily
           family cleanup
             task jgefs_atmos_post_cleanup
-              trigger ../post_processing/d0_16/atmos/jgefs_atmos_ensstat eq complete and ../post_processing/d0_16/atmos/jgefs_atmos_enspost eq complete and ../gempak/atmos/jgefs_atmos_gempak_meta eq complete
+              trigger ../init eq complete and ../chem eq complete and ../members eq complete and ../post_processing eq complete and ../gempak eq complete
           endfamily
         endfamily # v12.2
       endfamily # gefs

--- a/ecf/def/gefs_prod18.def
+++ b/ecf/def/gefs_prod18.def
@@ -32,7 +32,7 @@ suite prod
           endfamily
           family members
             family d0_16
-              edit ECF_FILES '/ecf/ecfnets/scripts/gefs/d0_16'
+              edit ECF_FILES '%PACKAGEHOME%/ecf/d0_16'
               family c00
                 edit MEMBER 'c00'
                 task jgefs_forecast
@@ -974,7 +974,7 @@ suite prod
                 trigger c00 == complete and p01 == complete and p02 == complete and p03 == complete and p04 == complete and p05 == complete and p06 == complete and p07 == complete and p08 == complete and p09 == complete and p10 == complete and p11 == complete and p12 == complete and p13 == complete and p14 == complete and p15 == complete and p16 == complete and p17 == complete and p18 == complete and p19 == complete and p20 == complete and p21 == complete and p22 == complete and p23 == complete and p24 == complete and p25 == complete and p26 == complete and p27 == complete and p28 == complete and p29 == complete and p30 == complete
             endfamily
             family d16_35
-              edit ECF_FILES '/ecf/ecfnets/scripts/gefs/d16_35'
+              edit ECF_FILES '%PACKAGEHOME%/ecf/d16_35'
               family c00
                 edit MEMBER 'c00'
                 family atmos
@@ -1094,7 +1094,7 @@ suite prod
           endfamily
           family cleanup
             task jgefs_atmos_post_cleanup
-              trigger ../post_processing/d0_16/atmos/jgefs_atmos_ensstat eq complete and ../post_processing/d0_16/atmos/jgefs_atmos_enspost eq complete and ../gempak/atmos/jgefs_atmos_gempak_meta eq complete
+              trigger ../init eq complete and ../chem eq complete and ../members eq complete and ../post_processing eq complete and ../gempak eq complete
           endfamily
         endfamily # v12.2
       endfamily # gefs

--- a/ecf/post_processing/d0_16/atmos/jgefs_atmos_ensavg_nemsio.ecf
+++ b/ecf/post_processing/d0_16/atmos/jgefs_atmos_ensavg_nemsio.ecf
@@ -3,8 +3,8 @@
 #PBS -S /bin/bash
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
-#PBS -l walltime=2:30:00
-#PBS -l place=vscatter,select=1:prepost=true:ncpus=30:mpiprocs=30:mem=240GB
+#PBS -l walltime=2:00:00
+#PBS -l place=vscatter,select=1:prepost=false:ncpus=30:mpiprocs=30:mem=240GB
 #PBS -l debug=true
 
 set -x

--- a/gempak/ush/gefs_meta_850.sh_comb
+++ b/gempak/ush/gefs_meta_850.sh_comb
@@ -112,8 +112,8 @@ for area in us sam; do
 
 			fn=ukmet
 			rm -rf ${fn}
-			if [ -r ${COMINukmet}.${ECM_PDY}/ukmet_hr_${ECM_PDY}${ECM_cyc}f${fcsthr_ecm} ]; then
-				ln -s ${COMINukmet}.${ECM_PDY}/ukmet_hr_${ECM_PDY}${ECM_cyc}f${fcsthr_ecm} ${fn}
+			if [ -r ${COMINukmet}.${ECM_PDY}/gempak/ukmet_hr_${ECM_PDY}${ECM_cyc}f${fcsthr_ecm} ]; then
+				ln -s ${COMINukmet}.${ECM_PDY}/gempak/ukmet_hr_${ECM_PDY}${ECM_cyc}f${fcsthr_ecm} ${fn}
 			fi
 
 			fn=dgex

--- a/gempak/ush/gefs_meta_carib_spag.sh_comb
+++ b/gempak/ush/gefs_meta_carib_spag.sh_comb
@@ -119,8 +119,8 @@ for pres in 200 250 300; do
 
 			fn=ukmet
 			rm -rf ${fn}
-			if [ -r ${COMINukmet}.${ECM_PDY}/ukmet_hr_${ECM_PDY}${ECM_cyc}f${fcsthr_ecm} ]; then
-				ln -s ${COMINukmet}.${ECM_PDY}/ukmet_hr_${ECM_PDY}${ECM_cyc}f${fcsthr_ecm} ${fn}
+			if [ -r ${COMINukmet}.${ECM_PDY}/gempak/ukmet_hr_${ECM_PDY}${ECM_cyc}f${fcsthr_ecm} ]; then
+				ln -s ${COMINukmet}.${ECM_PDY}/gempak/ukmet_hr_${ECM_PDY}${ECM_cyc}f${fcsthr_ecm} ${fn}
 			fi
 
 			fn=dgex

--- a/gempak/ush/gefs_meta_hi_spag.sh_comb
+++ b/gempak/ush/gefs_meta_hi_spag.sh_comb
@@ -104,8 +104,8 @@ for level in ${levels}; do
 
 		fn=ukmet
 		rm -rf ${fn}
-		if [ -r ${COMINukmet}.${ECM_PDY}/ukmet_${ECM_PDY}${ECM_cyc}f${fcsthr_ecm} ]; then
-			ln -s ${COMINukmet}.${ECM_PDY}/ukmet_${ECM_PDY}${ECM_cyc}f${fcsthr_ecm} ${fn}
+		if [ -r ${COMINukmet}.${ECM_PDY}/gempak/ukmet_${ECM_PDY}${ECM_cyc}f${fcsthr_ecm} ]; then
+			ln -s ${COMINukmet}.${ECM_PDY}/gempak/ukmet_${ECM_PDY}${ECM_cyc}f${fcsthr_ecm} ${fn}
 		fi
 
 		#fn=cmc

--- a/gempak/ush/gefs_meta_lows.sh_comb
+++ b/gempak/ush/gefs_meta_lows.sh_comb
@@ -131,8 +131,8 @@ for area in nam us trop sam hi; do
 
 		fn=ukmet
 		rm -rf ${fn}
-		if [ -r ${COMINukmet}.${ECM_PDY}/ukmet_hr_${ECM_PDY}${ECM_cyc}f${fcsthr_ecm} ]; then
-			ln -s ${COMINukmet}.${ECM_PDY}/ukmet_hr_${ECM_PDY}${ECM_cyc}f${fcsthr_ecm} ${fn}
+		if [ -r ${COMINukmet}.${ECM_PDY}/gempak/ukmet_hr_${ECM_PDY}${ECM_cyc}f${fcsthr_ecm} ]; then
+			ln -s ${COMINukmet}.${ECM_PDY}/gempak/ukmet_hr_${ECM_PDY}${ECM_cyc}f${fcsthr_ecm} ${fn}
 		fi
 
 		fn=dgex

--- a/gempak/ush/gefs_meta_mar_00Z.sh
+++ b/gempak/ush/gefs_meta_mar_00Z.sh
@@ -91,8 +91,8 @@ for metaarea in pac atl; do
 
 			fn=ukmet
 			rm -rf ${fn}
-			if [ -r ${COMINukmet}.${PDY}/ukmet_hr_${PDY}${cyc}f${fcsthr} ]; then
-				ln -s ${COMINukmet}.${PDY}/ukmet_hr_${PDY}${cyc}f${fcsthr} ${fn}
+			if [ -r ${COMINukmet}.${PDY}/gempak/ukmet_hr_${PDY}${cyc}f${fcsthr} ]; then
+				ln -s ${COMINukmet}.${PDY}/gempak/ukmet_hr_${PDY}${cyc}f${fcsthr} ${fn}
 			fi
 
 
@@ -278,8 +278,8 @@ for metaarea in pac atl; do
 
 		fn=ukmet
 		rm -rf ${fn}
-		if [ -r $COMINukmet.${PDY}/ukmet_hr_${PDY}${cyc}f${fcsthr} ]; then
-			ln -s $COMINukmet.${PDY}/ukmet_hr_${PDY}${cyc}f${fcsthr} ${fn}
+		if [ -r $COMINukmet.${PDY}/gempak/ukmet_hr_${PDY}${cyc}f${fcsthr} ]; then
+			ln -s $COMINukmet.${PDY}/gempak/ukmet_hr_${PDY}${cyc}f${fcsthr} ${fn}
 		fi
 
 		export pgm=gdplot2_nc;. prep_step; startmsg

--- a/gempak/ush/gefs_meta_nam_spag.sh_comb
+++ b/gempak/ush/gefs_meta_nam_spag.sh_comb
@@ -126,8 +126,8 @@ for level in ${levels}; do
 
 		fn=ukmet
 		rm -rf ${fn}
-		if [ -r ${COMINukmet}.${ECM_PDY}/ukmet_hr_${ECM_PDY}${ECM_cyc}f${fcsthr_ecm} ]; then
-			ln -s ${COMINukmet}.${ECM_PDY}/ukmet_hr_${ECM_PDY}${ECM_cyc}f${fcsthr_ecm} ${fn}
+		if [ -r ${COMINukmet}.${ECM_PDY}/gempak/ukmet_hr_${ECM_PDY}${ECM_cyc}f${fcsthr_ecm} ]; then
+			ln -s ${COMINukmet}.${ECM_PDY}/gempak/ukmet_hr_${ECM_PDY}${ECM_cyc}f${fcsthr_ecm} ${fn}
 		fi
 
 		fn=dgex

--- a/gempak/ush/gefs_meta_sam_spag.sh_comb
+++ b/gempak/ush/gefs_meta_sam_spag.sh_comb
@@ -123,14 +123,14 @@ for level in ${levels}; do
 
 		fn=ecmwf
 		rm -rf ${fn}
-		if [ -r $COMINecmwf/ecmwf.${ECM_PDY}/gempak/ecmwf_hr_${ECM_PDY}${ECM_cyc}f${fcsthr} ]; then
-			 ln -s $COMINecmwf/ecmwf.${ECM_PDY}/gempak/ecmwf_hr_${ECM_PDY}${ECM_cyc}f${fcsthr} ${fn}
+		if [ -r $COMINecmwf.${ECM_PDY}/gempak/ecmwf_hr_${ECM_PDY}${ECM_cyc}f${fcsthr} ]; then
+			 ln -s $COMINecmwf.${ECM_PDY}/gempak/ecmwf_hr_${ECM_PDY}${ECM_cyc}f${fcsthr} ${fn}
 		fi
 
 		fn=ukmet
 		rm -rf ${fn}
-		if [ -r ${COMINecmwf}.${ECM_PDY}/ukmet_${ECM_PDY}${ECM_cyc}f${fcsthr_ecm} ]; then
-			 ln -s ${COMINecmwf}.${ECM_PDY}/ukmet_${ECM_PDY}${ECM_cyc}f${fcsthr_ecm} ${fn}
+		if [ -r ${COMINukmet}.${ECM_PDY}/gempak/ukmet_${ECM_PDY}${ECM_cyc}f${fcsthr_ecm} ]; then
+			 ln -s ${COMINukmet}.${ECM_PDY}/gempak/ukmet_${ECM_PDY}${ECM_cyc}f${fcsthr_ecm} ${fn}
 		fi
 
 		fn=dgex

--- a/jobs/JGEFS_ATMOS_GEMPAK_META
+++ b/jobs/JGEFS_ATMOS_GEMPAK_META
@@ -89,7 +89,8 @@ done
 export COMINsgfs=${COMINsgfs:-$(compath.py $envir/com/gfs/${gfs_ver})}
 export COMINnawips=${COMINnawips:-$(compath.py $envir/com/nawips/${nawips_ver})}
 export COMINecmwf=${COMINecmwf:-$(compath.py $envir/com/ecmwf/${ecmwf_ver})/ecmwf}
-export COMINukmet=${COMINukmet:-$(compath.py $envir/com/nawips/${nawips_ver})/ukmet}
+#export COMINukmet=${COMINukmet:-$(compath.py $envir/com/nawips/${nawips_ver})/ukmet}
+export COMINukmet=${COMINukmet:-$(compath.py $envir/com/ukmet/${ukmet_ver})/ukmet}
 export COMINnam=${COMINnam:-$(compath.py $envir/com/nam/${nam_ver})}
 
 export COMPONENT=${COMPONENT:-atmos}

--- a/versions/run.ver
+++ b/versions/run.ver
@@ -6,6 +6,7 @@ export ecmwf_ver=v2.1
 export nawips_ver=v0.0
 export nam_ver=v4.2
 export obsproc_ver=v1.0
+export ukmet_ver=v2.2
 
 export envvar_ver=1.0
 export intel_ver=19.1.3.304


### PR DESCRIPTION
1) Use new ukmet gempak path
2) Improve jgefs_atmos_ensavg_nemsio.ecf
3) Improve ecf/def

 On branch feature/ops_sync_NCO
	modified:   ecf/def/gefs_prod00.def
	modified:   ecf/def/gefs_prod06.def
	modified:   ecf/def/gefs_prod12.def
	modified:   ecf/def/gefs_prod18.def
	modified:   ecf/post_processing/d0_16/atmos/jgefs_atmos_ensavg_nemsio.ecf
	modified:   gempak/ush/gefs_meta_850.sh_comb
	modified:   gempak/ush/gefs_meta_carib_spag.sh_comb
	modified:   gempak/ush/gefs_meta_hi_spag.sh_comb
	modified:   gempak/ush/gefs_meta_lows.sh_comb
	modified:   gempak/ush/gefs_meta_mar_00Z.sh
	modified:   gempak/ush/gefs_meta_nam_spag.sh_comb
	modified:   gempak/ush/gefs_meta_sam_spag.sh_comb
	modified:   jobs/JGEFS_ATMOS_GEMPAK_META
	modified:   versions/run.ver

Refs: #53